### PR TITLE
Add crop parameters (optional)

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,5 +1,4 @@
 from pydantic import BaseModel
-
 from panoptic.core.plugin.plugin import APlugin
 from panoptic.models import ActionContext, PropertyType, PropertyMode, DbCommit, Instance, ImageProperty, Property
 from panoptic.models.results import ActionResult
@@ -7,22 +6,28 @@ from panoptic.core.plugin.plugin_project_interface import PluginProjectInterface
 
 from doctr.io import DocumentFile
 from doctr.models import ocr_predictor
+from PIL import Image
 
 
 class PluginParams(BaseModel):
     """
     @ocr_prop_name: the name of the prop that will be created after an ocr
+    @crop_x, crop_y, crop_width, crop_height: Optional cropping parameters
     """
     ocr_prop_name: str = "ocr"
-  
+    crop_x: int = 0
+    crop_y: int = 0
+    crop_width: int = 0
+    crop_height: int = 0
+
   
 class OCRPlugin(APlugin):  
     def __init__(self, project: PluginProjectInterface, plugin_path: str, name: str):  
-        super().__init__(name=name,project=project, plugin_path=plugin_path)
+        super().__init__(name=name, project=project, plugin_path=plugin_path)
         self.params = PluginParams()  
         self.add_action_easy(self.ocr, ['execute'])
         self._model = ocr_predictor(pretrained=True, assume_straight_pages=True)
-  
+
     async def ocr(self, context: ActionContext):
         commit = DbCommit()
 
@@ -44,8 +49,19 @@ class OCRPlugin(APlugin):
         return ImageProperty(property_id=prop.id, sha1=instance.sha1, value=text)
 
     async def make_ocr(self, image_path):
-        single_img_doc = DocumentFile.from_images(image_path)
+        # Ouvrir l’image avec PIL pour appliquer le crop
+        with Image.open(image_path) as img:
+            if self.params.crop_width > 0 and self.params.crop_height > 0:
+                x, y, w, h = self.params.crop_x, self.params.crop_y, self.params.crop_width, self.params.crop_height
+                img = img.crop((x, y, x + w, y + h))
+
+            # Convertir en format utilisable par Doctr
+            single_img_doc = DocumentFile.from_images(img)
+
+        # Effectuer l'OCR
         result = self._model(single_img_doc)
+
+        # Extraire le texte reconnu avec un seuil de confiance de 0.50
         res = ""
         js = result.export()
         for block in js['pages'][0]['blocks']:
@@ -53,4 +69,5 @@ class OCRPlugin(APlugin):
                 for word in line['words']:
                     if word['confidence'] > 0.50:
                         res += " " + word['value']
+        
         return res


### PR DESCRIPTION
🔹 Explication des ajouts :
Ajout de paramètres crop_x, crop_y, crop_width, crop_height dans PluginParams.
Modification de make_ocr pour appliquer le recadrage avant l’OCR.
Utilisation de PIL.Image.crop() pour découper l’image si une zone est spécifiée.
Condition pour ne pas cropper si crop_width ou crop_height est à 0.

🔥 Exemple d'utilisation :
Si on veut ne traiter que la partie de l'image située à (x=100, y=200), de taille 300x400 :

```
plugin.params.crop_x = 100
plugin.params.crop_y = 200
plugin.params.crop_width = 300
plugin.params.crop_height = 400
```

Cela fera en sorte que l'OCR ne soit appliqué que sur cette portion.

💡 Avantages de cette approche : ✅ Permet de sélectionner une zone précise d'intérêt.
✅ Optimise les performances en évitant d’analyser toute l’image.
✅ Simple à activer ou désactiver (il suffit de mettre crop_width=0 pour désactiver le recadrage).